### PR TITLE
add support for relative jump instructions (JMPR, JROT, JROF)

### DIFF
--- a/tests/data/fdef133.txt
+++ b/tests/data/fdef133.txt
@@ -1,0 +1,50 @@
+FDEF[], 133
+
+/* support fn for fns 134 and 135
+
+   CALL[], &lt;align?&gt;, &lt;from&gt;, &lt;to&gt;, 133 */
+
+#BEGIN
+#PUSHOFF
+
+SWAP[]
+
+/* STACK: &lt;align?&gt;, &lt;to&gt;, &lt;from&gt; */
+
+#WBeginLoop133:
+
+#PUSH, 2 /* to */
+CINDEX[]
+#PUSH, 2 /* from */
+CINDEX[]
+GTEQ[]
+IF[]
+
+    /* STACK: &lt;align?&gt;, &lt;to&gt;, &lt;from&gt; */
+
+    DUP[]
+    #PUSH, 4 /* align? */
+    CINDEX[]
+    IF[]
+        ALIGNRP[]
+    ELSE[]
+        IP[]
+    EIF[]
+
+    #PUSH, 1
+    ADD[]
+
+    #PUSH, WOffset133
+    JMPR[], (WOffset133=#WBeginLoop133)
+
+EIF[]
+
+/* STACK: &lt;align?&gt;, &lt;to&gt;, &lt;from&gt; */
+
+POP[]
+POP[]
+POP[]
+
+#PUSHON
+#END
+ENDF[]

--- a/tests/data/fdef133_transformed.txt
+++ b/tests/data/fdef133_transformed.txt
@@ -1,0 +1,32 @@
+PUSHB[ ]    /* 1 value pushed */
+133
+FDEF[ ] /* FunctionDefinition */
+  SWAP[ ]   /* SwapTopStack */
+  PUSHB[ ]  /* 1 value pushed */
+  2
+  CINDEX[ ] /* CopyXToTopStack */
+  PUSHB[ ]  /* 1 value pushed */
+  2
+  CINDEX[ ] /* CopyXToTopStack */
+  GTEQ[ ]   /* GreaterThanOrEqual */
+  IF[ ] /* If */
+    DUP[ ]  /* DuplicateTopStack */
+    PUSHB[ ]    /* 1 value pushed */
+    4
+    CINDEX[ ]   /* CopyXToTopStack */
+    IF[ ]   /* If */
+      ALIGNRP[ ]    /* AlignRelativePt */
+    ELSE[ ] /* Else */
+      IP[ ] /* InterpolatePts */
+    EIF[ ]  /* EndIf */
+    PUSHB[ ]    /* 1 value pushed */
+    1
+    ADD[ ]  /* Add */
+    PUSHW[ ]    /* 1 value pushed */
+    -23
+    JMPR[ ] /* Jump */
+  EIF[ ]    /* EndIf */
+  POP[ ]    /* PopTopStack */
+  POP[ ]    /* PopTopStack */
+  POP[ ]    /* PopTopStack */
+ENDF[ ] /* EndFunctionDefinition */

--- a/tests/data/fdef152.txt
+++ b/tests/data/fdef152.txt
@@ -1,0 +1,147 @@
+FDEF[], 152
+/* Function 152 takes 1 argument, a "bitfield" flag. */
+/* VERSION 1.0 20111117 */
+/*
+Function 152 is intended to take a set of one or more bits as input and do an AND (e.g. mask) of those
+bits with the set of flags returned by Function 84. Then determine if there is at least one
+of these resultant bits that are set.
+
+Function 152 returns TRUE if the match is successful, and FALSE if it is not successful.
+
+If the parameter is zero, indicating no flags, then the function returns FALSE.
+
+This function takes a maxiumum of 32 bit flags.
+
+USES: Storage 2 (FN 84)
+RETURNS: 0 or 1
+*/
+
+#BEGIN
+#PUSHOFF
+/* Input parameter is a set of one or more flags */
+
+DUP[]
+#PUSH, 2     /* Read FN 84 flags */
+RS[]
+EQ[]         /* If a simple match, return TRUE */
+#PUSH, 1
+SWAP[]
+
+#PUSH, BEcln
+SWAP[]
+JROT[], (BEcln=#LEndClear)  /* Jump to end and clean up stack. */
+POP[]
+#PUSH, 0, 2
+RS[]         /* Read FN 84 flags */
+#PUSH, BEclr /* If no FN 84 flags, return FALSE */
+SWAP[]
+
+JROF[], (BEclr=#LEndClear)
+
+POP[]
+#PUSH, 2
+RS[]
+SWAP[]
+#PUSH, 32   /* Maximum number of bits to loop through */
+/* TopLoop: */
+#LTopLoop:
+   /* STACK
+   Loop Iteration Count
+   Updated (shifted) Input Value
+   Updated (shifted) FN 84 Flag
+   */
+  DUP[]
+  NOT[]
+  IF[]    /* Exit the loop when done */
+    POP[]
+    POP[]
+    POP[]
+    #PUSH, 0, BDEnd /* 73  End */
+
+    JMPR[], (BDEnd=#LEndFn)
+
+  EIF[]
+  ROLL[]
+  ROLL[]
+  DUP[]
+  ROLL[]
+  DUP[]
+  ROLL[]
+  SWAP[]
+  /* STACK
+  Updated (shifted) FN 84 Flag
+  Updated (shifted) Input Value
+  Updated (shifted) FN 84 Flag
+  Updated (Shifted) Input Value
+  Loop Interation Count
+  */
+
+  /* Check to see if the lower-order bit is set in the FN 84 Flag */
+  #PUSH, 4096 /* Convert to 26.6 by multiply by 64 x 64 */
+  MUL[]
+  ODD[]
+  IF[]
+    /* Check to see if the lower-order bit is set in the Input Value */
+    #PUSH, 4096
+    MUL[]
+    ODD[]
+    IF[]
+      /* We can early out here once we find our first match */
+      POP[]
+      POP[]
+      POP[]
+      #PUSH, 1, BTEnd  /* 1 is the TRUE return code */
+      JMPR[], (BTEnd=#LEndFn)
+    EIF[]
+  ELSE[]
+    POP[]
+  EIF[]
+  /* STACK
+  Updated (shifted) FN 84 Flag
+  Updated (shifted) Input Value
+  Loop Interation Count
+  */
+  /* Shift both the Input Value and the FN 84 Flag each one bit right */
+  #PUSH, 128  /* 2 in 26.6 */
+  DIV[]
+  DUP[]
+  NOT[]
+  IF[]
+    POP[]
+    POP[]
+    POP[]
+    #PUSH, 0, BPEnd /* 0 is end condition of FALSE */
+
+    JMPR[], (BPEnd=#LEndFn)
+
+  EIF[]
+  SWAP[]
+  #PUSH, 128  /* 2 in 26.6 */
+  DIV[]
+  DUP[]
+  NOT[]
+  IF[]
+    POP[]
+    POP[]
+    POP[]
+    #PUSH, 0, BZEnd /* End */
+
+    JMPR[], (BZEnd=#LEndFn) 
+
+  EIF[]
+  ROLL[]
+  #PUSH, 1
+  SUB[]
+  #PUSH, WReLoop  /* -77 TopLoop */
+
+JMPR[], (WReLoop=#LTopLoop)
+
+/* EndClear: */
+#LEndClear:
+SWAP[]
+POP[]
+#LEndFn:
+/* End: */
+#END
+#PUSHON
+ENDF[]

--- a/tests/data/fdef152_transformed.txt
+++ b/tests/data/fdef152_transformed.txt
@@ -1,0 +1,112 @@
+PUSHB[ ]  /* 1 value pushed */
+152
+FDEF[ ] /* FunctionDefinition */
+  DUP[ ]  /* DuplicateTopStack */
+  PUSHB[ ]  /* 1 value pushed */
+  2
+  RS[ ] /* ReadStore */
+  EQ[ ] /* Equal */
+  PUSHB[ ]  /* 1 value pushed */
+  1
+  SWAP[ ] /* SwapTopStack */
+  PUSHW[ ]  /* 1 value pushed */
+  104
+  SWAP[ ] /* SwapTopStack */
+  JROT[ ] /* JumpRelativeOnTrue */
+  POP[ ]  /* PopTopStack */
+  PUSHB[ ]  /* 2 values pushed */
+  0 2
+  RS[ ] /* ReadStore */
+  PUSHW[ ]  /* 1 value pushed */
+  94
+  SWAP[ ] /* SwapTopStack */
+  JROF[ ] /* JumpRelativeOnFalse */
+  POP[ ]  /* PopTopStack */
+  PUSHB[ ]  /* 1 value pushed */
+  2
+  RS[ ] /* ReadStore */
+  SWAP[ ] /* SwapTopStack */
+  PUSHB[ ]  /* 1 value pushed */
+  32
+  DUP[ ]  /* DuplicateTopStack */
+  NOT[ ]  /* LogicalNot */
+  IF[ ] /* If */
+    POP[ ]  /* PopTopStack */
+    POP[ ]  /* PopTopStack */
+    POP[ ]  /* PopTopStack */
+    PUSHB[ ]  /* 1 value pushed */
+    0
+    PUSHW[ ]  /* 1 value pushed */
+    77
+    JMPR[ ] /* Jump */
+  EIF[ ]  /* EndIf */
+  ROLL[ ] /* RollTopThreeStack */
+  ROLL[ ] /* RollTopThreeStack */
+  DUP[ ]  /* DuplicateTopStack */
+  ROLL[ ] /* RollTopThreeStack */
+  DUP[ ]  /* DuplicateTopStack */
+  ROLL[ ] /* RollTopThreeStack */
+  SWAP[ ] /* SwapTopStack */
+  PUSHW[ ]  /* 1 value pushed */
+  4096
+  MUL[ ]  /* Multiply */
+  ODD[ ]  /* Odd */
+  IF[ ] /* If */
+    PUSHW[ ]  /* 1 value pushed */
+    4096
+    MUL[ ]  /* Multiply */
+    ODD[ ]  /* Odd */
+    IF[ ] /* If */
+      POP[ ]  /* PopTopStack */
+      POP[ ]  /* PopTopStack */
+      POP[ ]  /* PopTopStack */
+      PUSHB[ ]  /* 1 value pushed */
+      1
+      PUSHW[ ]  /* 1 value pushed */
+      48
+      JMPR[ ] /* Jump */
+    EIF[ ]  /* EndIf */
+  ELSE[ ] /* Else */
+    POP[ ]  /* PopTopStack */
+  EIF[ ]  /* EndIf */
+  PUSHB[ ]  /* 1 value pushed */
+  128
+  DIV[ ]  /* Divide */
+  DUP[ ]  /* DuplicateTopStack */
+  NOT[ ]  /* LogicalNot */
+  IF[ ] /* If */
+    POP[ ]  /* PopTopStack */
+    POP[ ]  /* PopTopStack */
+    POP[ ]  /* PopTopStack */
+    PUSHB[ ]  /* 1 value pushed */
+    0
+    PUSHW[ ]  /* 1 value pushed */
+    29
+    JMPR[ ] /* Jump */
+  EIF[ ]  /* EndIf */
+  SWAP[ ] /* SwapTopStack */
+  PUSHB[ ]  /* 1 value pushed */
+  128
+  DIV[ ]  /* Divide */
+  DUP[ ]  /* DuplicateTopStack */
+  NOT[ ]  /* LogicalNot */
+  IF[ ] /* If */
+    POP[ ]  /* PopTopStack */
+    POP[ ]  /* PopTopStack */
+    POP[ ]  /* PopTopStack */
+    PUSHB[ ]  /* 1 value pushed */
+    0
+    PUSHW[ ]  /* 1 value pushed */
+    12
+    JMPR[ ] /* Jump */
+  EIF[ ]  /* EndIf */
+  ROLL[ ] /* RollTopThreeStack */
+  PUSHB[ ]  /* 1 value pushed */
+  1
+  SUB[ ]  /* Subtract */
+  PUSHW[ ]  /* 1 value pushed */
+  -85
+  JMPR[ ] /* Jump */
+  SWAP[ ] /* SwapTopStack */
+  POP[ ]  /* PopTopStack */
+ENDF[ ] /* EndFunctionDefinition */

--- a/tests/data/fdef153.txt
+++ b/tests/data/fdef153.txt
@@ -1,0 +1,173 @@
+FDEF[], 153
+/* Function 153 takes 1 argument, a "bitfield" flag. */
+/* VERSION 1.0 20111117 */
+/*
+Function 153 is intended to take a set of one or more bits as input and do an AND (e.g. mask) of those
+bits with the set of flags returned by Function 84. Then determine if ALL
+of these resultant bits from the mask are set.
+
+Function 153 returns TRUE if the match is successful, and FALSE if it is not successful.
+
+If the parameter is zero, indicating no flags, then the function returns FALSE.
+
+This function takes a maxiumum of 32 flags.
+
+USES: Storage 2 (FN 84)
+RETURNS: 0 or 1
+*/
+
+#BEGIN
+#PUSHOFF
+/* Input parameter is a set of one or more flags */
+
+DUP[]
+#PUSH, 2     /* Read FN 84 flags */
+RS[]
+EQ[]         /* If a simple match, return TRUE */
+#PUSH, 1
+SWAP[]
+
+#PUSH, BEcln
+SWAP[]
+JROT[], (BEcln=#LEndClear)  /* Jump to end and clean up stack. */
+POP[]
+#PUSH, 0, 2
+RS[]         /* Read FN 84 flags */
+#PUSH, BEclr /* If no FN 84 flags, return FALSE */
+SWAP[]
+
+JROF[], (BEclr=#LEndClear)
+
+POP[]
+#PUSH, 0, 2   /* 0 is the boolean tracking success, start off with FALSE */
+RS[]
+ROLL[]
+#PUSH, 32   /* Maximum number of bits to loop through */
+/* TopLoop: */
+#LTopLoop:
+   /* STACK
+   Loop Iteration Count
+   Updated (shifted) Input Value
+   Updated (shifted) FN 84 Flag
+   Conditional boolean tracking success
+   */
+  DUP[]
+  NOT[]
+  IF[]    /* Exit the loop when done */
+    POP[]
+    POP[]
+    POP[]
+    #PUSH, BDEnd /* 73  End */
+
+    JMPR[], (BDEnd=#LEndFn)
+
+  EIF[]
+  ROLL[]
+  ROLL[]
+  DUP[]
+  ROLL[]
+  DUP[]
+  ROLL[]
+  SWAP[]
+  /* STACK
+  Updated (shifted) FN 84 Flag
+  Updated (shifted) Input Value
+  Updated (shifted) FN 84 Flag
+  Updated (Shifted) Input Value
+  Loop Interation Count
+  Conditional boolean tracking success
+  */
+
+  /* Check to see if the lower-order bit is set in the FN 84 Flag */
+  #PUSH, 4096 /* Convert to 26.6 by multiply by 64 x 64 */
+  MUL[]
+  ODD[]
+  IF[]
+    /* Check to see if the lower-order bit is set in the Input Value */
+    #PUSH, 4096
+    MUL[]
+    ODD[]
+    IF[]
+      #PUSH, 4
+      MINDEX[]
+      #PUSH, 1  /* Set TRUE return code */
+      OR[]      /* We OR this because we will immediately exit if we fail this test */
+      #PUSH, 4
+      MINDEX[]
+      #PUSH, 4
+      MINDEX[]
+      #PUSH, 4
+      MINDEX[]
+    ELSE[]
+      POP[]
+      POP[]
+      POP[]
+      POP[]
+      #PUSH, BTEnd , 0  /* 0 is the FALSE return code */
+      SWAP[]
+      JMPR[], (BTEnd=#LEndFn)
+
+    EIF[]
+  ELSE[]
+    POP[]
+  EIF[]
+  #PUSH, 4 /* Can this be cleaned up and integrated with the code below? */
+  MINDEX[]
+  SWAP[]
+  /* STACK
+  Updated (shifted) FN 84 Flag
+  Conditional boolean tracking success
+  Updated (shifted) Input Value
+  Loop Interation Count
+  */
+  /* Shift both the Input Value and the FN 84 Flag each one bit right */
+  #PUSH, 128  /* 2 in 26.6 */
+  DIV[]
+  DUP[]
+  NOT[]
+  IF[]
+    ROLL[]
+    NOT[]
+    ROLL[]
+    AND[]
+    SWAP[]
+    POP[]
+    SWAP[]
+    POP[]
+    #PUSH, BPEnd /* 29  End */
+
+    JMPR[], (BPEnd=#LEndFn)
+
+  EIF[]
+  ROLL[]
+  #PUSH, 128  /* 2 in 26.6 */
+  DIV[]
+  DUP[]
+  NOT[]
+  IF[]
+    POP[]
+    POP[]
+    SWAP[]
+    POP[]
+    #PUSH, BZEnd /* End */
+
+    JMPR[], (BZEnd=#LEndFn)
+
+  EIF[]
+  #PUSH, 4
+  MINDEX[]
+  #PUSH, 1
+  SUB[]
+  #PUSH, WReLoop  /* -77 TopLoop */
+
+JMPR[], (WReLoop=#LTopLoop)
+
+/* EndClear: */
+#LEndClear:
+SWAP[]
+POP[]
+#LEndFn:
+/* End: */
+#END
+#PUSHON
+ENDF[]

--- a/tests/data/fdef153_transformed.txt
+++ b/tests/data/fdef153_transformed.txt
@@ -1,0 +1,136 @@
+PUSHB[ ]  /* 1 value pushed */
+153
+FDEF[ ] /* FunctionDefinition */
+  DUP[ ]  /* DuplicateTopStack */
+  PUSHB[ ]  /* 1 value pushed */
+  2
+  RS[ ] /* ReadStore */
+  EQ[ ] /* Equal */
+  PUSHB[ ]  /* 1 value pushed */
+  1
+  SWAP[ ] /* SwapTopStack */
+  PUSHW[ ]  /* 1 value pushed */
+  129
+  SWAP[ ] /* SwapTopStack */
+  JROT[ ] /* JumpRelativeOnTrue */
+  POP[ ]  /* PopTopStack */
+  PUSHB[ ]  /* 2 values pushed */
+  0 2
+  RS[ ] /* ReadStore */
+  PUSHW[ ]  /* 1 value pushed */
+  119
+  SWAP[ ] /* SwapTopStack */
+  JROF[ ] /* JumpRelativeOnFalse */
+  POP[ ]  /* PopTopStack */
+  PUSHB[ ]  /* 2 values pushed */
+  0 2
+  RS[ ] /* ReadStore */
+  ROLL[ ] /* RollTopThreeStack */
+  PUSHB[ ]  /* 1 value pushed */
+  32
+  DUP[ ]  /* DuplicateTopStack */
+  NOT[ ]  /* LogicalNot */
+  IF[ ] /* If */
+    POP[ ]  /* PopTopStack */
+    POP[ ]  /* PopTopStack */
+    POP[ ]  /* PopTopStack */
+    PUSHW[ ]  /* 1 value pushed */
+    103
+    JMPR[ ] /* Jump */
+  EIF[ ]  /* EndIf */
+  ROLL[ ] /* RollTopThreeStack */
+  ROLL[ ] /* RollTopThreeStack */
+  DUP[ ]  /* DuplicateTopStack */
+  ROLL[ ] /* RollTopThreeStack */
+  DUP[ ]  /* DuplicateTopStack */
+  ROLL[ ] /* RollTopThreeStack */
+  SWAP[ ] /* SwapTopStack */
+  PUSHW[ ]  /* 1 value pushed */
+  4096
+  MUL[ ]  /* Multiply */
+  ODD[ ]  /* Odd */
+  IF[ ] /* If */
+    PUSHW[ ]  /* 1 value pushed */
+    4096
+    MUL[ ]  /* Multiply */
+    ODD[ ]  /* Odd */
+    IF[ ] /* If */
+      PUSHB[ ]  /* 1 value pushed */
+      4
+      MINDEX[ ] /* MoveXToTopStack */
+      PUSHB[ ]  /* 1 value pushed */
+      1
+      OR[ ] /* LogicalOr */
+      PUSHB[ ]  /* 1 value pushed */
+      4
+      MINDEX[ ] /* MoveXToTopStack */
+      PUSHB[ ]  /* 1 value pushed */
+      4
+      MINDEX[ ] /* MoveXToTopStack */
+      PUSHB[ ]  /* 1 value pushed */
+      4
+      MINDEX[ ] /* MoveXToTopStack */
+    ELSE[ ] /* Else */
+      POP[ ]  /* PopTopStack */
+      POP[ ]  /* PopTopStack */
+      POP[ ]  /* PopTopStack */
+      POP[ ]  /* PopTopStack */
+      PUSHW[ ]  /* 1 value pushed */
+      56
+      PUSHB[ ]  /* 1 value pushed */
+      0
+      SWAP[ ] /* SwapTopStack */
+      JMPR[ ] /* Jump */
+    EIF[ ]  /* EndIf */
+  ELSE[ ] /* Else */
+    POP[ ]  /* PopTopStack */
+  EIF[ ]  /* EndIf */
+  PUSHB[ ]  /* 1 value pushed */
+  4
+  MINDEX[ ] /* MoveXToTopStack */
+  SWAP[ ] /* SwapTopStack */
+  PUSHB[ ]  /* 1 value pushed */
+  128
+  DIV[ ]  /* Divide */
+  DUP[ ]  /* DuplicateTopStack */
+  NOT[ ]  /* LogicalNot */
+  IF[ ] /* If */
+    ROLL[ ] /* RollTopThreeStack */
+    NOT[ ]  /* LogicalNot */
+    ROLL[ ] /* RollTopThreeStack */
+    AND[ ]  /* LogicalAnd */
+    SWAP[ ] /* SwapTopStack */
+    POP[ ]  /* PopTopStack */
+    SWAP[ ] /* SwapTopStack */
+    POP[ ]  /* PopTopStack */
+    PUSHW[ ]  /* 1 value pushed */
+    30
+    JMPR[ ] /* Jump */
+  EIF[ ]  /* EndIf */
+  ROLL[ ] /* RollTopThreeStack */
+  PUSHB[ ]  /* 1 value pushed */
+  128
+  DIV[ ]  /* Divide */
+  DUP[ ]  /* DuplicateTopStack */
+  NOT[ ]  /* LogicalNot */
+  IF[ ] /* If */
+    POP[ ]  /* PopTopStack */
+    POP[ ]  /* PopTopStack */
+    SWAP[ ] /* SwapTopStack */
+    POP[ ]  /* PopTopStack */
+    PUSHW[ ]  /* 1 value pushed */
+    14
+    JMPR[ ] /* Jump */
+  EIF[ ]  /* EndIf */
+  PUSHB[ ]  /* 1 value pushed */
+  4
+  MINDEX[ ] /* MoveXToTopStack */
+  PUSHB[ ]  /* 1 value pushed */
+  1
+  SUB[ ]  /* Subtract */
+  PUSHW[ ]  /* 1 value pushed */
+  -109
+  JMPR[ ] /* Jump */
+  SWAP[ ] /* SwapTopStack */
+  POP[ ]  /* PopTopStack */
+ENDF[ ] /* EndFunctionDefinition */

--- a/tests/data/fdef83.txt
+++ b/tests/data/fdef83.txt
@@ -1,0 +1,117 @@
+FDEF[], 83
+
+/* CALL[], &lt;radicand&gt;, 83
+
+   returns with square root of radicand on stack */
+
+#BEGIN
+#PUSHOFF
+
+/* STACK: &lt;radicand&gt; */
+
+#PUSH, 0, 2
+CINDEX[]
+
+/* STACK: &lt;radicand&gt;, &lt;low&gt;, &lt;high&gt; */
+
+#WBeginLoop83:
+
+    #PUSH, 2 /* low */
+    CINDEX[]
+    #PUSH, 2 /* high */
+    CINDEX[]
+    GTEQ[]
+    #PUSH, WOffset83a
+    SWAP[]
+    JROT[], (WOffset83a=#WEndLoop83) /* while low &lt;= high */
+
+    /* STACK: &lt;radicand&gt;, &lt;low&gt;, &lt;high&gt; */
+
+    #PUSH, 2 /* low */
+    CINDEX[]
+    #PUSH, 2 /* high */
+    CINDEX[]
+    ADD[]
+    #PUSH, 32
+    MUL[]
+
+    /* STACK: &lt;radicand&gt;, &lt;low&gt;, &lt;high&gt;, &lt;mid&gt; */
+
+    DUP[]
+    DUP[]
+    #PUSH, 6 /* radicand */
+    CINDEX[]
+    SWAP[]
+    DIV[]
+
+    /* STACK: &lt;radicand&gt;, &lt;low&gt;, &lt;high&gt;, &lt;mid&gt;, &lt;mid&gt;, &lt;radicand/mid&gt; */
+
+    LT[]
+    IF[]
+
+        /* STACK: &lt;radicand&gt;, &lt;low&gt;, &lt;high&gt;, &lt;mid&gt; */
+
+        ROLL[]
+        POP[]
+        #PUSH, 1
+        ADD[]
+        SWAP[]
+
+        /* STACK: &lt;radicand&gt;, &lt;mid+1&gt;, &lt;high&gt; */
+
+    ELSE[]
+
+        DUP[]
+        DUP[]
+        #PUSH, 6 /* radicand */
+        CINDEX[]
+        SWAP[]
+        DIV[]
+
+        GT[]
+        IF[]
+
+            /* STACK: &lt;radicand&gt;, &lt;low&gt;, &lt;high&gt;, &lt;mid&gt; */
+
+            SWAP[]
+            POP[]
+            #PUSH, 1
+            SUB[]
+
+            /* STACK: &lt;radicand&gt;, &lt;low&gt;, &lt;mid-1&gt; */
+
+        ELSE[]
+
+            /* STACK: &lt;radicand&gt;, &lt;low&gt;, &lt;high&gt;, &lt;mid&gt; */
+
+            ROLL[]
+            POP[]
+            SWAP[]
+            POP[]
+            DUP[]
+
+            /* STACK: &lt;radicand&gt;, &lt;mid&gt;, &lt;mid&gt; */
+
+        EIF[]
+
+    EIF[]
+
+
+    #PUSH, WOffset83b
+    JMPR[], (WOffset83b=#WBeginLoop83)
+
+#WEndLoop83:
+
+/* STACK: &lt;radicand&gt;, &lt;low&gt;, &lt;high&gt; */
+
+ADD[]
+#PUSH, 32
+MUL[]
+SWAP[]
+POP[]
+
+/* STACK: &lt;mid&gt; */
+
+#PUSHON
+#END
+ENDF[]

--- a/tests/data/fdef83_transformed.txt
+++ b/tests/data/fdef83_transformed.txt
@@ -1,0 +1,75 @@
+PUSHB[ ]	/* 1 value pushed */
+83
+FDEF[ ]	/* FunctionDefinition */
+  PUSHB[ ]	/* 2 values pushed */
+  0 2
+  CINDEX[ ]	/* CopyXToTopStack */
+  PUSHB[ ]	/* 1 value pushed */
+  2
+  CINDEX[ ]	/* CopyXToTopStack */
+  PUSHB[ ]	/* 1 value pushed */
+  2
+  CINDEX[ ]	/* CopyXToTopStack */
+  GTEQ[ ]	/* GreaterThanOrEqual */
+  PUSHW[ ]	/* 1 value pushed */
+  53
+  SWAP[ ]	/* SwapTopStack */
+  JROT[ ]	/* JumpRelativeOnTrue */
+  PUSHB[ ]	/* 1 value pushed */
+  2
+  CINDEX[ ]	/* CopyXToTopStack */
+  PUSHB[ ]	/* 1 value pushed */
+  2
+  CINDEX[ ]	/* CopyXToTopStack */
+  ADD[ ]	/* Add */
+  PUSHB[ ]	/* 1 value pushed */
+  32
+  MUL[ ]	/* Multiply */
+  DUP[ ]	/* DuplicateTopStack */
+  DUP[ ]	/* DuplicateTopStack */
+  PUSHB[ ]	/* 1 value pushed */
+  6
+  CINDEX[ ]	/* CopyXToTopStack */
+  SWAP[ ]	/* SwapTopStack */
+  DIV[ ]	/* Divide */
+  LT[ ]	/* LessThan */
+  IF[ ]	/* If */
+    ROLL[ ]	/* RollTopThreeStack */
+    POP[ ]	/* PopTopStack */
+    PUSHB[ ]	/* 1 value pushed */
+    1
+    ADD[ ]	/* Add */
+    SWAP[ ]	/* SwapTopStack */
+  ELSE[ ]	/* Else */
+    DUP[ ]	/* DuplicateTopStack */
+    DUP[ ]	/* DuplicateTopStack */
+    PUSHB[ ]	/* 1 value pushed */
+    6
+    CINDEX[ ]	/* CopyXToTopStack */
+    SWAP[ ]	/* SwapTopStack */
+    DIV[ ]	/* Divide */
+    GT[ ]	/* GreaterThan */
+    IF[ ]	/* If */
+      SWAP[ ]	/* SwapTopStack */
+      POP[ ]	/* PopTopStack */
+      PUSHB[ ]	/* 1 value pushed */
+      1
+      SUB[ ]	/* Subtract */
+    ELSE[ ]	/* Else */
+      ROLL[ ]	/* RollTopThreeStack */
+      POP[ ]	/* PopTopStack */
+      SWAP[ ]	/* SwapTopStack */
+      POP[ ]	/* PopTopStack */
+      DUP[ ]	/* DuplicateTopStack */
+    EIF[ ]	/* EndIf */
+  EIF[ ]	/* EndIf */
+  PUSHW[ ]	/* 1 value pushed */
+  -63
+  JMPR[ ]	/* Jump */
+  ADD[ ]	/* Add */
+  PUSHB[ ]	/* 1 value pushed */
+  32
+  MUL[ ]	/* Multiply */
+  SWAP[ ]	/* SwapTopStack */
+  POP[ ]	/* PopTopStack */
+ENDF[ ]	/* EndFunctionDefinition */

--- a/tests/vttLib_test.py
+++ b/tests/vttLib_test.py
@@ -1,8 +1,154 @@
-# This is just to exercise the test runner... :P
-# TODO: add some real unit tests!
-
+from vttLib import transform_assembly, make_ft_program, pformat_tti
+import os
+from textwrap import dedent
 import pytest
 
 
-def test_import():
-    import vttLib
+DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "data")
+
+
+TEST_NAMES = [
+    'fdef83',
+    'fdef133',
+    'fdef152',
+    'fdef153',
+]
+
+
+@pytest.fixture(params=TEST_NAMES)
+def test_name(request):
+    return request.param
+
+
+@pytest.fixture()
+def input_and_expected(request, test_name):
+    inpuf_filename = test_name + ".txt"
+    with open(os.path.join(DATA_DIR, inpuf_filename)) as fp:
+        input_vtt_assembly = fp.read()
+
+    expected_filename = test_name + "_transformed.txt" 
+    with open(os.path.join(DATA_DIR, expected_filename)) as fp:
+        expected_ft_assembly = fp.read()
+    ft_program = make_ft_program(expected_ft_assembly)
+    expected_ft_assembly = pformat_tti(ft_program)
+
+    return input_vtt_assembly, expected_ft_assembly
+
+
+class TransformAssemblyTest(object):
+
+    def test_empty(self):
+        assert not transform_assembly("")
+
+    def test_ignore_overlap(self):
+        ft_assembly = transform_assembly("OVERLAP[]")
+        assert not ft_assembly
+
+    def test_jump_back(self):
+        vtt_assembly = dedent("""
+            #PUSH, 1
+            DUP[]
+            #Label1:
+            DUP[]
+            DUP[]
+            DUP[]
+            #PUSH, Var1
+            JMPR[], (Var1=#Label1)
+        """)
+
+        ft_assembly = transform_assembly(vtt_assembly)
+
+        assert ft_assembly == dedent("""
+            PUSH[] 1
+            DUP[]
+            DUP[]
+            DUP[]
+            DUP[]
+            PUSHW[] -6
+            JMPR[]
+        """).strip()
+
+    def test_jump_forward(self):
+        vtt_assembly = dedent("""
+            #PUSH, Var1
+            JMPR[], (Var1=#Label1)
+            DUP[]
+            DUP[]
+            #PUSH, 1, 2
+            DUP[]
+            #Label1:
+            DUP[]
+            DUP[]
+        """)
+
+        ft_assembly = transform_assembly(vtt_assembly)
+
+        assert ft_assembly == dedent("""
+            PUSHW[] 7
+            JMPR[]
+            DUP[]
+            DUP[]
+            PUSH[] 1 2
+            DUP[]
+            DUP[]
+            DUP[]
+        """).strip()
+
+    def test_jump_mixed_args(self):
+        vtt_assembly = dedent("""
+            #PUSH, Var1, 1
+            JROT[], (Var1=#Label1)
+            DUP[]
+            DUP[]
+            DUP[]
+            #Label1:
+            DUP[]
+        """)
+
+        ft_assembly = transform_assembly(vtt_assembly)
+
+        assert ft_assembly == dedent("""
+            PUSHW[] 4
+            PUSH[] 1
+            JROT[]
+            DUP[]
+            DUP[]
+            DUP[]
+            DUP[]
+        """).strip()
+
+    def test_jump_repeated_args(self):
+
+        vtt_assembly = dedent("""
+            #PUSH, 0, Var1, Var1, -1
+            POP[]
+            SWAP[]
+            JROF[], (Var1=#Label1)
+            DUP[]
+            DUP[]
+            #Label1:
+            DUP[]
+        """)
+
+        ft_assembly = transform_assembly(vtt_assembly)
+
+        assert ft_assembly == dedent("""
+            PUSH[] 0
+            PUSHW[] 3 3
+            PUSH[] -1
+            POP[]
+            SWAP[]
+            JROF[]
+            DUP[]
+            DUP[]
+            DUP[]
+        """).strip()
+    
+    def test_end_to_end(self, input_and_expected):
+        vtt_assembly, expected = input_and_expected
+
+        ft_assembly = transform_assembly(vtt_assembly)
+        ft_program = make_ft_program(ft_assembly)
+        generated = pformat_tti(ft_program)
+
+        assert expected == generated


### PR DESCRIPTION
these are used in VTT 6.20 `fpgm` template and use some special syntax (see vttLib_test.py for examples)